### PR TITLE
Use LLVM 3.8 & other suggestions

### DIFF
--- a/build-coreclr
+++ b/build-coreclr
@@ -8,7 +8,7 @@ grep "Microsoft.NETCore.Runtime.CoreCLR" ../core-setup/pkg/projects/Microsoft.NE
 BUILD_NUMBER_MAJOR=$(cat version.txt | sed 's/.*-beta-//' | sed 's/-.*//')
 BUILD_NUMBER_MINOR=$(cat version.txt | sed 's/.*-beta-.*-//' | sed 's/".*//')
 sed -i 's/\-O[23]/-O1/' src/pal/tools/clang-compiler-override.txt
-ROOTFS_DIR=$ROOTFS_DIR BuildNumberMajor=$BUILD_NUMBER_MAJOR BuildNumberMinor=$BUILD_NUMBER_MINOR ./build.sh $ARCH $BUILD_CONFIG cross skiptests
+ROOTFS_DIR=$ROOTFS_DIR BuildNumberMajor=$BUILD_NUMBER_MAJOR BuildNumberMinor=$BUILD_NUMBER_MINOR ./build.sh $ARCH $BUILD_CONFIG clang3.8 cross skiptests
 cd ..
 
 mkdir -p packages

--- a/build-corefx
+++ b/build-corefx
@@ -10,7 +10,7 @@ fi
 grep "Microsoft.Private.CoreFx.NETCoreApp" ../core-setup/pkg/projects/Microsoft.NETCore.App/project.json.template > version.txt
 BUILD_NUMBER_MAJOR=$(cat version.txt | sed 's/.*-beta-//' | sed 's/-.*//')
 BUILD_NUMBER_MINOR=$(cat version.txt | sed 's/.*-beta-.*-//' | sed 's/".*//')
-ROOTFS_DIR=$ROOTFS_DIR ./run.sh build-native -buildArch=$ARCH -os=$OS_NAME -SkipTests -$BUILD_CONFIG -- cross
+ROOTFS_DIR=$ROOTFS_DIR ./run.sh build-native -buildArch=$ARCH -os=$OS_NAME -SkipTests -$BUILD_CONFIG -- cross clang3.8
 ROOTFS_DIR=$ROOTFS_DIR ./run.sh build-managed -buildArch=$ARCH -os=$OS_NAME -SkipTests -ConfigurationGroup=$BUILD_CONFIG -runtimeos=$RUNTIME_ID_BASE -BuildNumberMajor=$BUILD_NUMBER_MAJOR -BuildNumberMinor=$BUILD_NUMBER_MINOR
 ROOTFS_DIR=$ROOTFS_DIR ./run.sh build-managed -buildArch=$ARCH -os=$OS_NAME -SkipTests -ConfigurationGroup=$BUILD_CONFIG -runtimeos=$RUNTIME_ID_BASE -BuildNumberMajor=$BUILD_NUMBER_MAJOR -BuildNumberMinor=$BUILD_NUMBER_MINOR -packages
 cd ..

--- a/setup
+++ b/setup
@@ -5,7 +5,7 @@ set -e
 
 sudo apt-get -y update
 sudo apt-get -y dist-upgrade
-sudo apt-get -y install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev uuid-dev qemu qemu-user-static binfmt-support debootstrap binutils-arm-linux-gnueabihf clang-3.6 llvm-3.6 g++-arm-linux-gnueabihf gyp unzip libtool automake devscripts debhelper
+sudo apt-get -y install cmake llvm-3.8 clang-3.8 lldb-3.8 lldb-3.8-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev uuid-dev qemu qemu-user-static binfmt-support debootstrap binutils-arm-linux-gnueabihf clang-3.8 llvm-3.8 g++-arm-linux-gnueabihf gyp unzip libtool automake devscripts debhelper
 
 if [ ! -f "libicu52_52.1-8_amd64.deb" ]; then
   wget http://launchpadlibrarian.net/201330288/libicu52_52.1-8_amd64.deb
@@ -13,31 +13,48 @@ fi
 sudo dpkg -i libicu52_52.1-8_amd64.deb
 
 if [ ! -d "libuv" ]; then
-  git clone git@github.com:libuv/libuv
+  git clone https://github.com/libuv/libuv
+else
+  git -C libuv pull
 fi
 
 if [ ! -d "coreclr" ]; then
-  git clone git@github.com:dotnet/coreclr
+  git clone https://github.com/dotnet/coreclr
+else
+  git -C coreclr pull
 fi
 
 if [ ! -d "corefx" ]; then
-  git clone git@github.com:dotnet/corefx
+  git clone https://github.com/dotnet/corefx
+else
+  git -C corefx pull
 fi
 
 if [ ! -d "sdk" ]; then
-  git clone git@github.com:dotnet/sdk
+  git clone https://github.com/dotnet/sdk
+else
+  git -C sdk pull
 fi
 
 if [ ! -d "roslyn" ]; then
-  git clone git@github.com:dotnet/roslyn
+  git clone https://github.com/dotnet/roslyn
+else
+  git -C roslyn pull
 fi
 
 if [ ! -d "core-setup" ]; then
-  git clone git@github.com:dotnet/core-setup
+  git clone https://github.com/dotnet/core-setup
+else
+  git -C core-setup pull
 fi
 
 if [ ! -d "cli" ]; then
-  git clone git@github.com:dotnet/cli
+  git clone https://github.com/dotnet/cli
+  git -C cli remote add qmfrederik https://github.com/qmfrederik/cli
+  git -C cli fetch qmfrederik
+  git -C cli cherry-pick 14d8f808fc74181a8ec38c4173c0ccf74f2f6bc9
+else
+  git -C cli pull
 fi
 
 if [ ! -d "$ROOTFS_DIR" ]; then


### PR DESCRIPTION
Great job putting together the build scripts!

Here are a couple of changes I'd like to propose:
- We've seen our fair share of problems when compiling for ARM with older versions of LLVM. This PR bumps the version of LLVM used to 3.8, the latest version available natively on Ubuntu 16.04
- The setup script will do a git pull of all the repos if the repo already exists
- For the CLI repo, I also cherry-pick a commit which (partially?) enables cross-building the CLI.